### PR TITLE
Missing Module Added in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 yt-dlp
+pyinstaller
+pyperclip


### PR DESCRIPTION
You forgot to add **pyperclip** & **pyinstaller** in requirements.txt.